### PR TITLE
Preparation for 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ class CustomFilter extends AbstractFilter
      * @param  mixed                                $value
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    abstract public function handle(Builder $builder, $value);
+    public function handle(Builder $builder, $value)
+    {
+        return $builder->where($this->column, '=', $value);
+    }
 }
 ```
 

--- a/src/Contracts/Filters/Filter.php
+++ b/src/Contracts/Filters/Filter.php
@@ -7,14 +7,14 @@ use Illuminate\Database\Eloquent\Builder;
 interface Filter
 {
     /**
-     * @param \Illuminate\Database\Eloquent\Builder $builder
-     * @param string                                $column
-     * @param                                       $value
+     * @param string $column
      */
-    public function __construct(Builder $builder, string $column, $value);
+    public function __construct(string $column);
 
     /**
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param mixed                                 $value
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function handle();
+    public function handle(Builder $builder, $value);
 }

--- a/src/Contracts/Filters/Filter.php
+++ b/src/Contracts/Filters/Filter.php
@@ -10,7 +10,11 @@ interface Filter
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @param string                                $column
      * @param                                       $value
+     */
+    public function __construct(Builder $builder, string $column, $value);
+
+    /**
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function __invoke(Builder $builder, string $column, $value);
+    public function handle();
 }

--- a/src/Contracts/Sorters/Sorter.php
+++ b/src/Contracts/Sorters/Sorter.php
@@ -10,7 +10,11 @@ interface Sorter
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @param string                                $column
      * @param string                                $type
+     */
+    public function __construct(Builder $builder, string $column, string $type);
+
+    /**
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function __invoke(Builder $builder, string $column, string $type);
+    public function handle();
 }

--- a/src/Contracts/Sorters/Sorter.php
+++ b/src/Contracts/Sorters/Sorter.php
@@ -7,14 +7,14 @@ use Illuminate\Database\Eloquent\Builder;
 interface Sorter
 {
     /**
-     * @param \Illuminate\Database\Eloquent\Builder $builder
-     * @param string                                $column
-     * @param string                                $type
+     * @param string $column
      */
-    public function __construct(Builder $builder, string $column, string $type);
+    public function __construct(string $column);
 
     /**
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param string                                $type
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function handle();
+    public function handle(Builder $builder, string $type);
 }

--- a/src/Filterable.php
+++ b/src/Filterable.php
@@ -292,20 +292,19 @@ class Filterable
         }
 
         foreach ($parameters as $key => $value) {
-            $instance = $this->getFilterInstance($key, $value);
+            $instance = $this->getFilterInstance($key);
 
             if ($instance instanceof Filter) {
-                $instance->handle();
+                $instance->handle($this->getBuilder(), $value);
             }
         }
     }
 
     /**
      * @param string $key
-     * @param mixed  $value
      * @return \KoenHoeijmakers\LaravelFilterable\Contracts\Filters\Filter|null
      */
-    protected function getFilterInstance(string $key, $value)
+    protected function getFilterInstance(string $key)
     {
         if ($this->hasFilter($key)) {
             $instance = $this->getFilter($key);
@@ -315,7 +314,7 @@ class Filterable
             return null;
         }
 
-        return !$instance instanceof Filter ? new $instance($this->getBuilder(), $key, $value) : $instance;
+        return !$instance instanceof Filter ? new $instance($key) : $instance;
     }
 
     /**
@@ -349,19 +348,18 @@ class Filterable
             $this->config->get('filterable.keys.sort_desc')
         );
 
-        $instance = $this->getSorterInstance($sortBy, $sortDesc ? 'desc' : 'asc');
+        $instance = $this->getSorterInstance($sortBy);
 
         if ($instance instanceof Sorter) {
-            $instance->handle();
+            $instance->handle($this->getBuilder(), $sortDesc ? 'desc' : 'asc');
         }
     }
 
     /**
      * @param string $key
-     * @param string $type
      * @return \KoenHoeijmakers\LaravelFilterable\Contracts\Filters\Sorter|null
      */
-    protected function getSorterInstance(string $key, string $type)
+    protected function getSorterInstance(string $key)
     {
         if ($this->hasSorter($key)) {
             $instance = $this->getSorter($key);
@@ -371,7 +369,7 @@ class Filterable
             return null;
         }
 
-        return !$instance instanceof Sorter ? new $instance($this->getBuilder(), $key, $type) : $instance;
+        return !$instance instanceof Sorter ? new $instance($key) : $instance;
     }
 
     /**

--- a/src/Filters/AbstractFilter.php
+++ b/src/Filters/AbstractFilter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace KoenHoeijmakers\LaravelFilterable\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+use KoenHoeijmakers\LaravelFilterable\Contracts\Filters\Filter;
+
+abstract class AbstractFilter implements Filter
+{
+    /**
+     * @var \Illuminate\Database\Eloquent\Builder
+     */
+    protected $builder;
+
+    /**
+     * @var string
+     */
+    protected $column;
+
+    /**
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param string                                $column
+     * @param                                       $value
+     */
+    public function __construct(Builder $builder, string $column, $value)
+    {
+        $this->builder = $builder;
+        $this->column = $column;
+        $this->value = $value;
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    abstract public function handle();
+}

--- a/src/Filters/AbstractFilter.php
+++ b/src/Filters/AbstractFilter.php
@@ -8,34 +8,22 @@ use KoenHoeijmakers\LaravelFilterable\Contracts\Filters\Filter;
 abstract class AbstractFilter implements Filter
 {
     /**
-     * @var \Illuminate\Database\Eloquent\Builder
-     */
-    protected $builder;
-
-    /**
      * @var string
      */
     protected $column;
 
     /**
-     * @var mixed
+     * @param string $column
      */
-    protected $value;
-
-    /**
-     * @param \Illuminate\Database\Eloquent\Builder $builder
-     * @param string                                $column
-     * @param                                       $value
-     */
-    public function __construct(Builder $builder, string $column, $value)
+    public function __construct(string $column)
     {
-        $this->builder = $builder;
         $this->column = $column;
-        $this->value = $value;
     }
 
     /**
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param  mixed                                $value
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    abstract public function handle();
+    abstract public function handle(Builder $builder, $value);
 }

--- a/src/Sorters/AbstractSorter.php
+++ b/src/Sorters/AbstractSorter.php
@@ -8,34 +8,22 @@ use KoenHoeijmakers\LaravelFilterable\Contracts\Filters\Sorter;
 abstract class AbstractSorter implements Sorter
 {
     /**
-     * @var \Illuminate\Database\Eloquent\Builder
-     */
-    protected $builder;
-
-    /**
      * @var string
      */
     protected $column;
 
     /**
-     * @var string
+     * @param string $column
      */
-    protected $type;
-
-    /**
-     * @param \Illuminate\Database\Eloquent\Builder $builder
-     * @param string                                $column
-     * @param string                                $type
-     */
-    public function __construct(Builder $builder, string $column, string $type)
+    public function __construct(string $column)
     {
-        $this->builder = $builder;
         $this->column = $column;
-        $this->type = $type;
     }
 
     /**
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param string                                $type
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    abstract public function handle();
+    abstract public function handle(Builder $builder, string $type);
 }

--- a/src/Sorters/AbstractSorter.php
+++ b/src/Sorters/AbstractSorter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace KoenHoeijmakers\LaravelFilterable\Sorters;
+
+use Illuminate\Database\Eloquent\Builder;
+use KoenHoeijmakers\LaravelFilterable\Contracts\Filters\Sorter;
+
+abstract class AbstractSorter implements Sorter
+{
+    /**
+     * @var \Illuminate\Database\Eloquent\Builder
+     */
+    protected $builder;
+
+    /**
+     * @var string
+     */
+    protected $column;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param string                                $column
+     * @param string                                $type
+     */
+    public function __construct(Builder $builder, string $column, string $type)
+    {
+        $this->builder = $builder;
+        $this->column = $column;
+        $this->type = $type;
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    abstract public function handle();
+}


### PR DESCRIPTION
Filters and Sorters now have a different syntax that allow overriding the column,
this makes it easier to reuse a filter.

Say you have a query string of `q[date]=2018-06-10` and the actual searching is done on the `created_at` column, this wouldn't work as is now, but this version allows you to register filters with:
```
$filterable->registerFilter('date', new DateFilter('created_at'));
```
And as you'll see, the column is now overrideable.

(sorters work the same way).